### PR TITLE
Find functions to hook using user supplied module name

### DIFF
--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -412,15 +412,15 @@ class TorchHook(FrameworkHook):
                 if "native_" in func or f"native_{func}" in dir(torch_module):
                     continue
 
-                self._perform_function_overloading(torch_module, func)
+                self._perform_function_overloading(module_name, torch_module, func)
 
     @classmethod
-    def _get_hooked_func(cls, attr):
+    def _get_hooked_func(cls, public_module_name, attr):
         """Torch-specific implementation. See the subclass for more."""
         if attr.__module__ is None:
             attr.__module__ = "torch"
 
-        return super()._get_hooked_func(attr)
+        return super()._get_hooked_func(module_name, attr)
 
     def _get_hooked_additive_shared_method(hook_self, attr):
         """

--- a/syft/generic/frameworks/hook/hook.py
+++ b/syft/generic/frameworks/hook/hook.py
@@ -281,7 +281,7 @@ class FrameworkHook(ABC):
         tensor_type.__init__ = new___init__
 
     @classmethod
-    def _perform_function_overloading(cls, parent, func):
+    def _perform_function_overloading(cls, module_name, parent, func):
 
         # Where the overloading happens
         # 1. Get native function
@@ -289,7 +289,7 @@ class FrameworkHook(ABC):
         # 2. Check it is a proper function
         if type(native_func) in [types.FunctionType, types.BuiltinFunctionType]:
             # 3. Build the hooked function
-            new_func = cls._get_hooked_func(native_func)
+            new_func = cls._get_hooked_func(module_name, native_func)
             # 4. Move the native function
             setattr(parent, f"native_{func}", native_func)
             # 5. Put instead the hooked one
@@ -389,7 +389,7 @@ class FrameworkHook(ABC):
         return overloaded_native_method
 
     @classmethod
-    def _get_hooked_func(cls, attr):
+    def _get_hooked_func(cls, public_module_name, attr):
         """
         Hook a function in order to inspect its args and search for pointer
         or other syft tensors.
@@ -399,12 +399,14 @@ class FrameworkHook(ABC):
         - Calls with syft tensor will in the future trigger specific behaviour
 
         Args:
+            public_module_name (str): the name of the public module you are
+                hooking this function on (ie the same name that the user would import).
             attr (str): the method to hook
         Return:
             the hooked method
         """
 
-        cmd_name = f"{attr.__module__}.{attr.__name__}"
+        cmd_name = f"{public_module_name}.{attr.__name__}"
 
         @wraps(attr)
         def overloaded_func(*args, **kwargs):


### PR DESCRIPTION
Tensorflow uses swig to generate APIs and thus their module structure is
quite different than their public api.

in `_get_hooked_func` we would construct the command name to executed like so

```
cmd_name = f"{attr.__module__}.{attr.__name__}"
```

In torch, this was never a problem.  However, with Tensorflow, the attribute
module would often times not line up with the public API.  This uses the user supplied
API namespace for hooking so we can be more confident the API will be there.