### PR TITLE
revert object_type, pass  param to .wrap() instead

### DIFF
--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -182,9 +182,10 @@ class TorchHook(FrameworkHook):
     def create_shape(cls, shape_dims):
         return torch.Size(shape_dims)
 
-    def create_wrapper(cls, child_to_wrap):
+    def create_wrapper(cls, wrapper_type):
         # Note this overrides FrameworkHook.create_wrapper, so it must conform to
         # that classmethod's signature
+        assert wrapper_type is None or wrapper_type == torch.Tensor, "TorchHook only uses torch.Tensor wrappers"
         return torch.Tensor()
 
     def create_zeros(cls, *shape, dtype=None, **kwargs):

--- a/syft/generic/frameworks/attributes.py
+++ b/syft/generic/frameworks/attributes.py
@@ -25,6 +25,7 @@ class FrameworkAttributes(ABC):
     @classmethod
     @abstractmethod
     def Tensor(cls):
+        """Default Tensor wrapper."""
         pass
 
     @abstractmethod

--- a/syft/generic/frameworks/hook/hook.py
+++ b/syft/generic/frameworks/hook/hook.py
@@ -32,15 +32,16 @@ class FrameworkHook(ABC):
 
     @classmethod
     @abstractmethod
-    def create_wrapper(cls, child_to_wrap, *args, **kwargs):
-        """Factory method for creating a generic FrameworkTensor wrapper."""
-        pass
-
-    @classmethod
-    @abstractmethod
     def create_zeros(cls, shape, dtype, **kwargs):
         """Factory method for creating a generic zero FrameworkTensor."""
         pass
+
+    @classmethod
+    def create_wrapper(cls, wrapper_type, *args, **kwargs):
+        """Factory method for creating a generic wrapper of type wrapper_type."""
+        if wrapper_type is None:
+          wrapper_type = syft.framework.Tensor
+        return wrapper_type(*args, **kwargs)
 
     ### Standardized, framework-specific methods ###
     @abstractmethod

--- a/syft/generic/frameworks/types.py
+++ b/syft/generic/frameworks/types.py
@@ -4,7 +4,6 @@ from syft import dependency_check
 
 framework_tensors = []
 framework_shapes = []
-framework_object_type = []
 
 if dependency_check.tensorflow_available:
     import tensorflow as tf
@@ -12,8 +11,6 @@ if dependency_check.tensorflow_available:
 
     framework_tensors.append(EagerTensor)
     framework_shapes.append(tf.TensorShape)
-    framework_object_type.append(tf.Tensor)
-    framework_object_type.append(tf.Variable)
 
 if dependency_check.torch_available:
     import torch
@@ -21,7 +18,6 @@ if dependency_check.torch_available:
     framework_tensors.append(torch.Tensor)
     framework_tensors.append(torch.nn.Parameter)
     framework_shapes.append(torch.Size)
-    framework_object_type.append(torch.Tensor)
 
 framework_tensors = tuple(framework_tensors)
 FrameworkTensorType = Union[framework_tensors]
@@ -30,5 +26,3 @@ FrameworkTensor = framework_tensors
 framework_shapes = tuple(framework_shapes)
 FrameworkShapeType = Union[framework_shapes]
 FrameworkShape = framework_shapes
-
-FrameworkObjectType = framework_object_type

--- a/syft/generic/pointers/object_pointer.py
+++ b/syft/generic/pointers/object_pointer.py
@@ -10,7 +10,6 @@ from syft.generic.object import AbstractObject
 
 # this if statement avoids circular imports between base.py and pointer.py
 if TYPE_CHECKING:
-    from syft.generic.frameworks.types import FrameworkObjectType
     from syft.workers.base import BaseWorker
 
 
@@ -41,7 +40,6 @@ class ObjectPointer(AbstractObject):
         point_to_attr: str = None,
         tags: List[str] = None,
         description: str = None,
-        object_type: "FrameworkObjectType" = None,
     ):
 
         """Initializes a ObjectPointer.
@@ -64,10 +62,6 @@ class ObjectPointer(AbstractObject):
                 .grad. Note the string can be a chain (i.e., .child.child.child or
                 .grad.child.child). Defaults to None, which means don't point to any attr,
                 just point to then object corresponding to the id_at_location.
-            object_type: An optional FrameworkObjectType to specify the object type which should
-                match the child type (e.g. torch.Tensor, tf.Variable, tf.Tensor). This 
-                attribute can be useful for frameworks using several tensor types, to indicate 
-                how to wrap the ObjectPointer.
         """
         super().__init__(id=id, owner=owner, tags=tags, description=description)
 
@@ -75,7 +69,6 @@ class ObjectPointer(AbstractObject):
         self.id_at_location = id_at_location
         self.garbage_collect_data = garbage_collect_data
         self.point_to_attr = point_to_attr
-        self.object_type = object_type
 
     @classmethod
     def handle_func_command(cls, command):

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -6,7 +6,6 @@ from syft.generic.frameworks.hook.hook_args import one
 from syft.generic.frameworks.hook.hook_args import register_type_rule
 from syft.generic.frameworks.hook.hook_args import register_forward_func
 from syft.generic.frameworks.hook.hook_args import register_backward_func
-from syft.generic.frameworks.types import FrameworkObjectType
 from syft.generic.frameworks.types import FrameworkShapeType
 from syft.generic.frameworks.types import FrameworkTensor
 from syft.generic.tensor import AbstractTensor
@@ -57,7 +56,6 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         point_to_attr: str = None,
         tags: List[str] = None,
         description: str = None,
-        object_type: "FrameworkObjectType" = None,
     ):
         """Initializes a PointerTensor.
 
@@ -83,10 +81,6 @@ class PointerTensor(ObjectPointer, AbstractTensor):
             tags: an optional set of strings corresponding to this tensor
                 which this tensor should be searchable for.
             description: an optional string describing the purpose of the tensor.
-            object_type: An optional FrameworkObjectType to specify the object type which should
-                match the child type (e.g. torch.Tensor, tf.Variable, tf.Tensor). This 
-                attribute can be useful for frameworks using several tensor types to indicate 
-                how to wrap the PointerTensor.
         """
 
         super().__init__(
@@ -98,7 +92,6 @@ class PointerTensor(ObjectPointer, AbstractTensor):
             point_to_attr=point_to_attr,
             tags=tags,
             description=description,
-            object_type=object_type,
         )
         self._shape = shape
 
@@ -168,7 +161,6 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         shape=None,
         local_autograd=False,
         preinitialize_grad=False,
-        object_type=None,
     ) -> "PointerTensor":
         """Creates a pointer to the "self" FrameworkTensor object.
 
@@ -215,10 +207,6 @@ class PointerTensor(ObjectPointer, AbstractTensor):
             local_autograd: Use autograd system on the local machine instead of PyTorch's
                 autograd on the workers.
             preinitialize_grad: Initialize gradient for AutogradTensors to a tensor.
-            object_type: An optional FrameworkObjectType to specify the object type which should
-                match the child type (e.g. torch.Tensor, tf.Variable, tf.Tensor). This 
-                attribute can be useful for frameworks using several tensor types to indicate 
-                how to wrap the PointerTensor.
 
         Returns:
             A FrameworkTensor[PointerTensor] pointer to self. Note that this
@@ -246,7 +234,6 @@ class PointerTensor(ObjectPointer, AbstractTensor):
                 shape=shape,
                 tags=tensor.tags,
                 description=tensor.description,
-                object_type=object_type,
             )
 
         return ptr
@@ -450,6 +437,7 @@ class PointerTensor(ObjectPointer, AbstractTensor):
                         # if the tensor is not a wrapper BUT it's also not a torch tensor,
                         # then it needs to be wrapped or else it won't be able to be used
                         # by other interfaces
+                        import pdb; pdb.set_trace()
                         tensor = tensor.wrap()
 
             return tensor

--- a/syft/generic/tensor.py
+++ b/syft/generic/tensor.py
@@ -45,24 +45,25 @@ class AbstractTensor(AbstractObject):
             tensor.child = self
             return tensor
 
-    def wrap(self, register=True) -> FrameworkTensorType:
+    def wrap(self, register=True, type=None, **kwargs) -> FrameworkTensorType:
         """Wraps the class inside torch tensor.
 
-        Because PyTorch does not (yet) support functionality for creating
+        Because PyTorch/TF do not (yet) support functionality for creating
         arbitrary Tensor types (via subclassing torch.Tensor), in order for our
         new tensor types (such as PointerTensor) to be usable by the rest of
-        PyTorch (such as PyTorch's layers and loss functions), we need to wrap
-        all of our new tensor types inside of a native PyTorch type.
+        PyTorch/TF (such as PyTorch's layers and loss functions), we need to
+        wrap all of our new tensor types inside of a native PyTorch type.
 
         This function adds a .wrap() function to all of our tensor types (by
         adding it to AbstractTensor), such that (on any custom tensor
         my_tensor), my_tensor.wrap() will return a tensor that is compatible
-        with the rest of the PyTorch API.
+        with the rest of the PyTorch/TensorFlow API.
 
         Returns:
-            A pytorch tensor.
+            A wrapper tensor of class `type`, or whatever is specified as
+            default by the current syft.framework.Tensor.
         """
-        wrapper = sy.framework.hook.create_wrapper(self)
+        wrapper = sy.framework.hook.create_wrapper(type, **kwargs)
         wrapper.child = self
         wrapper.is_wrapper = True
         wrapper.child.parent = weakref.ref(wrapper)


### PR DESCRIPTION
after conversation with Theo via OM slack, we decided to try to shoot for passing the wrapper type to the `ptr.wrap()` method instead of having it be an `object_type` attribute on `ptr`